### PR TITLE
Metadata handling improvements and other fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
                 "--out",
                 "C:\\bad-inf-enc\\"
             ],
-            "cwd": "${workspaceFolder}/SngTool/SngCli",
+            "cwd": "${workspaceFolder}/SngTool/SngCli/bin/Debug/net7.0/win-x64/",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "integratedTerminal",
             "stopAtEntry": false

--- a/SngTool/SngCli/KnownKeys.cs
+++ b/SngTool/SngCli/KnownKeys.cs
@@ -2,54 +2,157 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using SngLib;
+using SongLib;
 
 namespace SngCli
 {
+    public enum IniValueType
+    {
+        Integer,
+        String,
+        Boolean,
+    }
+
     public static class KnownKeys
     {
-        private static readonly HashSet<string> knownMetdataKeys = new HashSet<string>() {
-            "name",
-            "artist",
-            "album",
-            "genre",
-            "year",
-            "diff_band",
-            "diff_guitar",
-            "diff_rhythm",
-            "diff_guitar_coop",
-            "diff_bass",
-            "diff_drums",
-            "diff_drums_real",
-            "diff_keys",
-            "diff_guitarghl",
-            "diff_bassghl",
-            "diff_guitar_coop_ghl",
-            "diff_rhythm_ghl",
-            "preview_start_time",
-            "icon",
-            "playlist_track",
-            "modchart",
-            "song_length",
-            "pro_drums",
-            "five_lane_drums",
-            "playlist",
-            "sub_playlist",
-            "album_track",
-            "track",
-            "charter",
-            "frets",
-            "hopo_frequency",
-            "eighthnote_hopo",
-            "multiplier_note",
-            "delay",
-            "video_start_time",
-            "end_events",
-            "loading_phrase"
+        private static readonly List<(string key, IniValueType type)> knownMetadata = new()
+        {
+            ( "name",                 IniValueType.String ),
+            ( "artist",               IniValueType.String ),
+            ( "album",                IniValueType.String ),
+            ( "genre",                IniValueType.String ),
+            ( "year",                 IniValueType.String ),
+
+            ( "charter",              IniValueType.String ),
+            ( "frets",                IniValueType.String ),
+            ( "icon",                 IniValueType.String ),
+            ( "loading_phrase",       IniValueType.String ),
+
+            ( "diff_band",            IniValueType.Integer ),
+            ( "diff_guitar",          IniValueType.Integer ),
+            ( "diff_rhythm",          IniValueType.Integer ),
+            ( "diff_guitar_coop",     IniValueType.Integer ),
+            ( "diff_bass",            IniValueType.Integer ),
+            ( "diff_drums",           IniValueType.Integer ),
+            ( "diff_drums_real",      IniValueType.Integer ),
+            ( "diff_keys",            IniValueType.Integer ),
+            ( "diff_guitarghl",       IniValueType.Integer ),
+            ( "diff_bassghl",         IniValueType.Integer ),
+            ( "diff_guitar_coop_ghl", IniValueType.Integer ),
+            ( "diff_rhythm_ghl",      IniValueType.Integer ),
+
+            ( "song_length",          IniValueType.Integer ),
+            ( "preview_start_time",   IniValueType.Integer ),
+            ( "video_start_time",     IniValueType.Integer ),
+            ( "delay",                IniValueType.Integer ),
+
+            ( "playlist_track",       IniValueType.Integer ),
+            ( "album_track",          IniValueType.Integer ),
+            ( "track",                IniValueType.Integer ),
+
+            ( "playlist",             IniValueType.String ),
+            ( "sub_playlist",         IniValueType.String ),
+
+            ( "multiplier_note",      IniValueType.Integer ),
+            ( "hopo_frequency",       IniValueType.Integer ),
+            ( "eighthnote_hopo",      IniValueType.Boolean ),
+
+            ( "pro_drums",            IniValueType.Boolean ),
+            ( "five_lane_drums",      IniValueType.Boolean ),
+            ( "end_events",           IniValueType.Boolean ),
+            ( "modchart",             IniValueType.Boolean ),
         };
+
+        private static readonly HashSet<string> knownMetadataKeys = knownMetadata.Select((v) => v.key).ToHashSet();
+    
+        private static readonly List<(string oldKey, string newKey)> legacyMetadataKeys = new()
+        {
+            ( "frets", "charter" ),
+            ( "track", "album_track" ),
+        };
+
+        private static readonly List<(string key, Func<string, string?> fixup)> metadataFixups = new()
+        {
+            ( "icon", (value) => value == "0" ? null : value.ToLowerInvariant() ),
+        };
+
+        public static void ValidateKeys(Dictionary<string, string> keys)
+        {
+            // Validate known metadata
+            foreach (var (key, type) in knownMetadata)
+            {
+                if (!keys.TryGetValue(key, out string? value))
+                {
+                    continue;
+                }
+
+                bool valid = type switch
+                {
+                    IniValueType.Integer => int.TryParse(value, out _),
+                    IniValueType.String => !string.IsNullOrEmpty(value),
+                    IniValueType.Boolean => bool.TryParse(value, out _) ||
+                        (int.TryParse(value, out int intBool) && intBool is 0 or 1),                            
+                    _ => throw new NotImplementedException($"Unrecognized IniValueType {type}")
+                };
+
+                if (!valid)
+                {
+                    if (Program.Verbose)
+                        ConMan.Out($"Removing invalid metadata. Key: {key} Value: {value} Type: {type}");
+
+                    keys.Remove(key);
+                }
+            }
+
+            // Apply any necessary fixups
+            foreach (var (key, fixup) in metadataFixups)
+            {
+                if (!keys.TryGetValue(key, out string? value))
+                    continue;
+
+                string? fixedValue = fixup(value);
+                if (!string.IsNullOrEmpty(fixedValue))
+                {
+                    if (Program.Verbose)
+                        ConMan.Out($"Applying fixup to metadata. Key: {key} Value: {value} Replacement: {fixedValue}");
+
+                    keys[key] = value;
+                }
+                else
+                {
+                    if (Program.Verbose)
+                        ConMan.Out($"Removing invalid metadata. Key: {key} Value: {value}");
+
+                    keys.Remove(key);
+                }
+            }
+
+            // Replace legacy metadata
+            foreach (var (oldKey, newKey) in legacyMetadataKeys)
+            {
+                if (!keys.TryGetValue(oldKey, out string? value))
+                    continue;
+
+                keys.Remove(oldKey);
+                if (!keys.ContainsKey(newKey))
+                {
+                    if (Program.Verbose)
+                        ConMan.Out($"Replacing legacy metadata {oldKey} with {newKey}");
+
+                    keys.Add(newKey, value);
+                }
+                else
+                {
+                    if (Program.Verbose)
+                        ConMan.Out($"Removing legacy metadata {oldKey}");
+                }
+            }
+        }
 
         public static bool IsKnownKey(string key)
         {
-            return knownMetdataKeys.TryGetValue(key, out _);
+            return knownMetadataKeys.Contains(key);
         }
     }
 }

--- a/SngTool/SngCli/KnownKeys.cs
+++ b/SngTool/SngCli/KnownKeys.cs
@@ -9,9 +9,15 @@ namespace SngCli
 {
     public enum IniValueType
     {
+        // Primitive
         Integer,
         String,
         Boolean,
+
+        // Complex
+        ColorCode,
+        IntegerPair,
+        ProGuitarTuning,
     }
 
     public static class KnownKeys
@@ -22,30 +28,50 @@ namespace SngCli
             ( "artist",               IniValueType.String ),
             ( "album",                IniValueType.String ),
             ( "genre",                IniValueType.String ),
+            ( "sub_genre",            IniValueType.String ),
             ( "year",                 IniValueType.String ),
 
             ( "charter",              IniValueType.String ),
             ( "frets",                IniValueType.String ),
-            ( "icon",                 IniValueType.String ),
-            ( "loading_phrase",       IniValueType.String ),
+            ( "version",              IniValueType.Integer ),
 
             ( "diff_band",            IniValueType.Integer ),
+
             ( "diff_guitar",          IniValueType.Integer ),
-            ( "diff_rhythm",          IniValueType.Integer ),
-            ( "diff_guitar_coop",     IniValueType.Integer ),
-            ( "diff_bass",            IniValueType.Integer ),
-            ( "diff_drums",           IniValueType.Integer ),
-            ( "diff_drums_real",      IniValueType.Integer ),
-            ( "diff_keys",            IniValueType.Integer ),
             ( "diff_guitarghl",       IniValueType.Integer ),
-            ( "diff_bassghl",         IniValueType.Integer ),
+            ( "diff_guitar_coop",     IniValueType.Integer ),
             ( "diff_guitar_coop_ghl", IniValueType.Integer ),
+            ( "diff_guitar_real",     IniValueType.Integer ),
+            ( "diff_guitar_real_22",  IniValueType.Integer ),
+
+            ( "diff_rhythm",          IniValueType.Integer ),
             ( "diff_rhythm_ghl",      IniValueType.Integer ),
 
+            ( "diff_bass",            IniValueType.Integer ),
+            ( "diff_bassghl",         IniValueType.Integer ),
+            ( "diff_bass_real",       IniValueType.Integer ),
+            ( "diff_bass_real_22",    IniValueType.Integer ),
+
+            ( "diff_drums",           IniValueType.Integer ),
+            ( "diff_drums_real",      IniValueType.Integer ),
+            ( "diff_drums_real_ps",   IniValueType.Integer ),
+
+            ( "diff_keys",            IniValueType.Integer ),
+            ( "diff_keys_real",       IniValueType.Integer ),
+            ( "diff_keys_real_ps",    IniValueType.Integer ),
+
+            ( "diff_vocals",          IniValueType.Integer ),
+            ( "diff_vocals_harm",     IniValueType.Integer ),
+
+            ( "diff_dance",           IniValueType.Integer ),
+
             ( "song_length",          IniValueType.Integer ),
-            ( "preview_start_time",   IniValueType.Integer ),
-            ( "video_start_time",     IniValueType.Integer ),
             ( "delay",                IniValueType.Integer ),
+            ( "preview_start_time",   IniValueType.Integer ),
+            ( "preview_end_time",     IniValueType.Integer ),
+            ( "preview",              IniValueType.IntegerPair ),
+            ( "video_start_time",     IniValueType.Integer ),
+            ( "video_end_time",       IniValueType.Integer ),
 
             ( "playlist_track",       IniValueType.Integer ),
             ( "album_track",          IniValueType.Integer ),
@@ -54,14 +80,66 @@ namespace SngCli
             ( "playlist",             IniValueType.String ),
             ( "sub_playlist",         IniValueType.String ),
 
-            ( "multiplier_note",      IniValueType.Integer ),
-            ( "hopo_frequency",       IniValueType.Integer ),
-            ( "eighthnote_hopo",      IniValueType.Boolean ),
+            ( "cover",                IniValueType.String ),
+            ( "icon",                 IniValueType.String ),
+            ( "background",           IniValueType.String ),
+            ( "video",                IniValueType.String ),
+            ( "video_loop",           IniValueType.Boolean ),
+
+            ( "link_name_a",          IniValueType.String ),
+            ( "link_name_b",          IniValueType.String ),
+            ( "banner_link_a",        IniValueType.String ),
+            ( "banner_link_b",        IniValueType.String ),
+
+            ( "cassettecolor",        IniValueType.ColorCode ),
+            ( "tags",                 IniValueType.String ),
+            ( "loading_phrase",       IniValueType.String ),
+
+            ( "tutorial",             IniValueType.Boolean ),
+            ( "boss_battle",          IniValueType.Boolean ),
+
+            ( "unlock_id",            IniValueType.String ),
+            ( "unlock_require",       IniValueType.String ),
+            ( "unlock_text",          IniValueType.String ),
+            ( "unlock_completed",     IniValueType.Integer ),
+
+            ( "sustain_cutoff_threshold", IniValueType.Integer ),
+            ( "multiplier_note",          IniValueType.Integer ),
+            ( "star_power_note",          IniValueType.Integer ),
+            ( "hopo_frequency",           IniValueType.Integer ),
+            ( "eighthnote_hopo",          IniValueType.Boolean ),
 
             ( "pro_drums",            IniValueType.Boolean ),
             ( "five_lane_drums",      IniValueType.Boolean ),
+            ( "drum_fallback_blue",   IniValueType.Boolean ),
+            ( "vocal_gender",         IniValueType.Boolean ),
+
+            ( "sysex_slider",         IniValueType.Boolean ),
+            ( "sysex_high_hat_ctrl",  IniValueType.Boolean ),
+            ( "sysex_rimshot",        IniValueType.Boolean ),
+            ( "sysex_open_bass",      IniValueType.Boolean ),
+            ( "sysex_pro_slide",      IniValueType.Boolean ),
+
+            ( "guitar_type",          IniValueType.Integer ),
+            ( "bass_type",            IniValueType.Integer ),
+            ( "kit_type",             IniValueType.Integer ),
+            ( "keys_type",            IniValueType.Integer ),
+            ( "dance_type",           IniValueType.Integer ),
+
+            ( "real_guitar_tuning",    IniValueType.ProGuitarTuning ),
+            ( "real_guitar_22_tuning", IniValueType.ProGuitarTuning ),
+            ( "real_bass_tuning",      IniValueType.ProGuitarTuning ),
+            ( "real_bass_22_tuning",   IniValueType.ProGuitarTuning ),
+
+            ( "real_keys_lane_count_right", IniValueType.Integer ),
+            ( "real_keys_lane_count_left",  IniValueType.Integer ),
+
+            ( "eof_midi_import_drum_accent_velocity", IniValueType.Integer ),
+            ( "eof_midi_import_drum_ghost_velocity",  IniValueType.Integer ),
+
             ( "end_events",           IniValueType.Boolean ),
             ( "modchart",             IniValueType.Boolean ),
+            ( "lyrics",               IniValueType.Boolean ),
         };
 
         private static readonly HashSet<string> knownMetadataKeys = knownMetadata.Select((v) => v.key).ToHashSet();
@@ -70,6 +148,8 @@ namespace SngCli
         {
             ( "frets", "charter" ),
             ( "track", "album_track" ),
+            ( "star_power_note", "multiplier_note" ),
+            ( "pro_drum", "pro_drums" ),
         };
 
         private static readonly List<(string key, Func<string, string?> fixup)> metadataFixups = new()
@@ -92,9 +172,67 @@ namespace SngCli
                     IniValueType.Integer => int.TryParse(value, out _),
                     IniValueType.String => !string.IsNullOrEmpty(value),
                     IniValueType.Boolean => bool.TryParse(value, out _) ||
-                        (int.TryParse(value, out int intBool) && intBool is 0 or 1),                            
+                        (int.TryParse(value, out int intBool) && intBool is 0 or 1),
+
+                    IniValueType.ColorCode => value.StartsWith('#') &&
+                        value.AsSpan().IndexOfAny("0123456789ABCDEFabcdef") < 0,
+                    IniValueType.IntegerPair => ValidateIntegerPair(value),
+                    IniValueType.ProGuitarTuning => ValidateProGuitarTuning(value),
+
                     _ => throw new NotImplementedException($"Unrecognized IniValueType {type}")
                 };
+
+                // preview = 35000 65000
+                static bool ValidateIntegerPair(ReadOnlySpan<char> text)
+                {
+                    int splitIndex = text.IndexOf(' ');
+                    if (splitIndex < 0)
+                        return false;
+
+                    var first = text.Slice(0, splitIndex);
+                    var second = text.Slice(splitIndex + 1);
+
+                    return int.TryParse(first, out _) && int.TryParse(second, out _);
+                }
+
+                // real_guitar_tuning = 0 0 0 0 0 0 "Standard tuning"
+                // real_guitar_22_tuning = 0 2 5 7 10 10
+                // real_bass_tuning = -2 0 0 0 "Drop D tuning"
+                // real_bass_22_tuning = 0 0 0 0 0
+                static bool ValidateProGuitarTuning(ReadOnlySpan<char> text)
+                {
+                    // Go through each number
+                    int numbers = 0;
+                    int splitIndex;
+                    while ((splitIndex = text.IndexOf(' ')) >= 0)
+                    {
+                        var split = text.Slice(0, splitIndex);
+                        if (!int.TryParse(split, out _))
+                            break;
+
+                        numbers++;
+                        text = text.Slice(splitIndex + 1);
+                    }
+
+                    // Handle remaining text
+                    if (int.TryParse(text, out _))
+                    {
+                        numbers++;
+                    }
+                    else
+                    {
+                        // Check for quoted segment
+                        int quoteStartIndex = text.IndexOf('"');
+                        if (quoteStartIndex >= 0)
+                        {
+                            var quoteEndSearch = text.Slice(quoteStartIndex + 1);
+                            if (quoteEndSearch.IndexOf('"') < 0)
+                                return false;
+                        }
+                    }
+
+                    return numbers is >= 4 and <= 6;
+                }
 
                 if (!valid)
                 {

--- a/SngTool/SngCli/SngCli.csproj
+++ b/SngTool/SngCli/SngCli.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable> 
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
     <InvariantGlobalization>true</InvariantGlobalization>
     <DebuggerSupport>false</DebuggerSupport>
     <PublishSingleFile>true</PublishSingleFile>

--- a/SngTool/SngCli/SngDecode.cs
+++ b/SngTool/SngCli/SngDecode.cs
@@ -81,14 +81,21 @@ namespace SngCli
                 return;
             }
 
+            var songs = FindAllSngFiles(conf.InputPath!);
+            if (songs.Length == 0)
+            {
+                ConMan.Out($"No valid songs found at: {conf.InputPath!}");
+                Environment.Exit(1);
+                return;
+            }
+
             if (conf.StatusBar)
             {
                 ConMan.EnableProgress(1);
             }
-            var songs = FindAllSngFiles(conf.InputPath!);
+
             ConMan.ProgressItems = songs.Length;
-
-
+            ConMan.Out($"Song count: {songs.Length}");
             await Utils.ForEachAsync(songs, async (sngFile, token) =>
             {
                 try

--- a/SngTool/SngCli/SngDecode.cs
+++ b/SngTool/SngCli/SngDecode.cs
@@ -17,123 +17,16 @@ namespace SngCli
 
         private static void SerializeMetadata(SngFile sngFile, string savePath)
         {
-            // Manually parse the types of known keys so that we know they are correct
-            // read from metadata
-            var name = sngFile.GetString("name", "");
-            var artist = sngFile.GetString("artist", "");
-            var album = sngFile.GetString("album", "");
-            var genre = sngFile.GetString("genre", "");
-            var year = sngFile.GetString("year", "");
-            var bandDiff = sngFile.GetInt("diff_band", -1);
-            var guitarDiff = sngFile.GetInt("diff_guitar", -1);
-            var rhythmDiff = sngFile.GetInt("diff_rhythm", -1);
-            var guitarCoopDiff = sngFile.GetInt("diff_guitar_coop", -1);
-            var bassDiff = sngFile.GetInt("diff_bass", -1);
-            var drumsDiff = sngFile.GetInt("diff_drums", -1);
-            var proDrumsDiff = sngFile.GetInt("diff_drums_real", -1);
-            var keysDiff = sngFile.GetInt("diff_keys", -1);
-            var gHLGuitarDiff = sngFile.GetInt("diff_guitarghl", -1);
-            var gHLBassDiff = sngFile.GetInt("diff_bassghl", -1);
-            var gHLGuitarCoopDiff = sngFile.GetInt("diff_guitar_coop_ghl", -1);
-            var gHLRhythmDiff = sngFile.GetInt("diff_rhythm_ghl", -1);
-            var previewStart = sngFile.GetInt("preview_start_time", -1);
-            var iconName = sngFile.GetString("icon", "").ToLowerInvariant();
-            var playlistTrack = sngFile.GetInt("playlist_track", 16000);
-            var modchart = sngFile.GetBool("modchart", false);
-            var songLength = sngFile.GetInt("song_length", 0);
-            var forceProDrums = sngFile.GetBool("pro_drums", false);
-            var forceFiveLane = sngFile.GetBool("five_lane_drums", false);
-            var topLevelPlaylist = sngFile.GetString("playlist", "").ToLowerInvariant();
-            var subPlaylist = sngFile.GetString("sub_playlist", "").ToLowerInvariant();
-            var albumTrack = sngFile.GetInt("album_track", 16000);
-            var charter = sngFile.GetString("charter", "");
-            var customHOPO = sngFile.GetInt("hopo_frequency", 0);
-            var isEighthHOPO = sngFile.GetBool("eighthnote_hopo", false);
-            var multiplierNote = sngFile.GetInt("multiplier_note", 0);
-            var offset = sngFile.GetInt("delay", 0);
-            var videoStart = sngFile.GetInt("video_start_time", 0);
-            var endEventsEnabled = sngFile.GetBool("end_events", true);
-            var loadingPhrase = sngFile.GetString("loading_phrase", "");
+            KnownKeys.ValidateKeys(sngFile.Metadata);
 
-            // write to ini
             IniFile iniFile = new IniFile();
-
-            iniFile.SetString("song", "name", name);
-            iniFile.SetString("song", "artist", artist);
-            iniFile.SetString("song", "album", album);
-            iniFile.SetString("song", "genre", genre);
-            iniFile.SetString("song", "year", year);
-            iniFile.SetInt("song", "diff_band", bandDiff);
-            iniFile.SetInt("song", "diff_guitar", guitarDiff);
-            iniFile.SetInt("song", "diff_rhythm", rhythmDiff);
-            iniFile.SetInt("song", "diff_guitar_coop", guitarCoopDiff);
-            iniFile.SetInt("song", "diff_bass", bassDiff);
-            iniFile.SetInt("song", "diff_drums", drumsDiff);
-            iniFile.SetInt("song", "diff_drums_real", proDrumsDiff);
-            iniFile.SetInt("song", "diff_keys", keysDiff);
-            iniFile.SetInt("song", "diff_guitarghl", gHLGuitarDiff);
-            iniFile.SetInt("song", "diff_bassghl", gHLBassDiff);
-            iniFile.SetInt("song", "diff_guitar_coop_ghl", gHLGuitarCoopDiff);
-            iniFile.SetInt("song", "diff_rhythm_ghl", gHLRhythmDiff);
-            iniFile.SetInt("song", "preview_start_time", previewStart);
-            iniFile.SetString("song", "icon", iconName);
-            iniFile.SetInt("song", "playlist_track", playlistTrack);
-            iniFile.SetBool("song", "modchart", modchart);
-            iniFile.SetInt("song", "song_length", songLength);
-            iniFile.SetBool("song", "pro_drums", forceProDrums);
-            iniFile.SetBool("song", "five_lane_drums", forceFiveLane);
-            iniFile.SetString("song", "playlist", topLevelPlaylist);
-            iniFile.SetString("song", "sub_playlist", subPlaylist);
-            iniFile.SetInt("song", "album_track", albumTrack);
-            iniFile.SetString("song", "charter", charter);
-            iniFile.SetInt("song", "hopo_frequency", customHOPO);
-            iniFile.SetBool("song", "eighthnote_hopo", isEighthHOPO);
-            iniFile.SetInt("song", "multiplier_note", multiplierNote);
-            iniFile.SetInt("song", "delay", offset);
-            iniFile.SetInt("song", "video_start_time", videoStart);
-            iniFile.SetBool("song", "end_events", endEventsEnabled);
-            iniFile.SetString("song", "loading_phrase", loadingPhrase);
-
-            // Load unknown metadata
-            foreach (var key in sngFile.Metadata.Keys)
+            foreach (var (key, value) in sngFile.Metadata)
             {
-                if (KnownKeys.IsKnownKey(key))
+                if (!KnownKeys.IsKnownKey(key) && Program.Verbose)
                 {
-                    continue;
+                    ConMan.Out($"Unknown metadata. Key: {key} Value: {value}");
                 }
-
-                if (sngFile.TryGetBool(key, out var boolVal))
-                {
-                    if (Program.Verbose)
-                    {
-                        ConMan.Out($"Unknown Key: {key} Value: {boolVal} BOOL");
-                    }
-                    iniFile.SetBool("song", key, boolVal);
-                }
-                else if (sngFile.TryGetInt(key, out var intVal))
-                {
-                    if (Program.Verbose)
-                    {
-                        ConMan.Out($"Unknown Key: {key} Value: {intVal} INT");
-                    }
-                    iniFile.SetInt("song", key, intVal);
-                }
-                else if (sngFile.TryGetInt(key, out var floatVal))
-                {
-                    if (Program.Verbose)
-                    {
-                        ConMan.Out($"Unknown Key: {key} Value: {floatVal} FLOAT");
-                    }
-                    iniFile.SetFloat("song", key, floatVal);
-                }
-                else if (sngFile.TryGetString(key, out var stringVal))
-                {
-                    if (Program.Verbose)
-                    {
-                        ConMan.Out($"Unknown Key: {key} Value: {stringVal} STRING");
-                    }
-                    iniFile.SetString("song", key, stringVal);
-                }
+                iniFile.SetString("song", key, value);
             }
 
             iniFile.Save(savePath);

--- a/SngTool/SngCli/SngEncode.cs
+++ b/SngTool/SngCli/SngEncode.cs
@@ -203,139 +203,25 @@ namespace SngCli
             {
                 return false;
             }
-            // Manually parse the types of known keys so that we know they are correct
+
             IniFile iniFile = new IniFile();
             iniFile.Load(iniPath);
-            if (iniFile.IsSection("song"))
-            {
-                var name = iniFile.GetString("song", "name", "");
-                var artist = iniFile.GetString("song", "artist", "");
-                var album = iniFile.GetString("song", "album", "");
-                var genre = iniFile.GetString("song", "genre", "");
-                var year = iniFile.GetString("song", "year", "");
-                var bandDiff = iniFile.GetInt("song", "diff_band", -1);
-                var guitarDiff = iniFile.GetInt("song", "diff_guitar", -1);
-                var rhythmDiff = iniFile.GetInt("song", "diff_rhythm", -1);
-                var guitarCoopDiff = iniFile.GetInt("song", "diff_guitar_coop", -1);
-                var bassDiff = iniFile.GetInt("song", "diff_bass", -1);
-                var drumsDiff = iniFile.GetInt("song", "diff_drums", -1);
-                var proDrumsDiff = iniFile.GetInt("song", "diff_drums_real", -1);
-                var keysDiff = iniFile.GetInt("song", "diff_keys", -1);
-                var gHLGuitarDiff = iniFile.GetInt("song", "diff_guitarghl", -1);
-                var gHLBassDiff = iniFile.GetInt("song", "diff_bassghl", -1);
-                var gHLGuitarCoopDiff = iniFile.GetInt("song", "diff_guitar_coop_ghl", -1);
-                var gHLRhythmDiff = iniFile.GetInt("song", "diff_rhythm_ghl", -1);
-                var previewStart = iniFile.GetInt("song", "preview_start_time", -1);
-                var iconName = iniFile.GetString("song", "icon", "").ToLowerInvariant();
-                var playlistTrack = iniFile.GetInt("song", "playlist_track", 16000);
-                var modchart = iniFile.GetBool("song", "modchart", false);
-                var songLength = iniFile.GetInt("song", "song_length", 0);
-                var forceProDrums = iniFile.GetBool("song", "pro_drums", false);
-                var forceFiveLane = iniFile.GetBool("song", "five_lane_drums", false);
-                var topLevelPlaylist = iniFile.GetString("song", "playlist", "").ToLowerInvariant();
-                var subPlaylist = iniFile.GetString("song", "sub_playlist", "").ToLowerInvariant();
-
-                int albumTrack;
-                if (iniFile.IsKey("song", "album_track"))
-                    albumTrack = iniFile.GetInt("song", "album_track", 16000);
-                else
-                    albumTrack = iniFile.GetInt("song", "track", 16000);
-
-                var charter = iniFile.GetString("song", iniFile.IsKey("song", "charter") ? "charter" : "frets", "");
-
-                var customHOPO = iniFile.GetInt("song", "hopo_frequency", 0);
-                var isEighthHOPO = iniFile.GetBool("song", "eighthnote_hopo", false);
-                var multiplierNote = iniFile.GetInt("song", "multiplier_note", 0);
-                var offset = iniFile.GetInt("song", "delay", 0);
-                var videoStart = iniFile.GetInt("song", "video_start_time", 0);
-                var endEventsEnabled = iniFile.GetBool("song", "end_events", true);
-                var loadingPhrase = iniFile.GetString("song", "loading_phrase", "");
-
-                // Save metadata to sng file
-                sngFile.SetString("name", name);
-                sngFile.SetString("artist", artist);
-                sngFile.SetString("album", album);
-                sngFile.SetString("genre", genre);
-                sngFile.SetString("year", year);
-                sngFile.SetInt("diff_band", bandDiff);
-                sngFile.SetInt("diff_guitar", guitarDiff);
-                sngFile.SetInt("diff_rhythm", rhythmDiff);
-                sngFile.SetInt("diff_guitar_coop", guitarCoopDiff);
-                sngFile.SetInt("diff_bass", bassDiff);
-                sngFile.SetInt("diff_drums", drumsDiff);
-                sngFile.SetInt("diff_drums_real", proDrumsDiff);
-                sngFile.SetInt("diff_keys", keysDiff);
-                sngFile.SetInt("diff_guitarghl", gHLGuitarDiff);
-                sngFile.SetInt("diff_bassghl", gHLBassDiff);
-                sngFile.SetInt("diff_guitar_coop_ghl", gHLGuitarCoopDiff);
-                sngFile.SetInt("diff_rhythm_ghl", gHLRhythmDiff);
-                sngFile.SetInt("preview_start_time", previewStart);
-                sngFile.SetString("icon", iconName);
-                sngFile.SetInt("playlist_track", playlistTrack);
-                sngFile.SetBool("modchart", modchart);
-                sngFile.SetInt("song_length", songLength);
-                sngFile.SetBool("pro_drums", forceProDrums);
-                sngFile.SetBool("five_lane_drums", forceFiveLane);
-                sngFile.SetString("playlist", topLevelPlaylist);
-                sngFile.SetString("sub_playlist", subPlaylist);
-                sngFile.SetInt("album_track", albumTrack);
-                sngFile.SetString("charter", charter);
-                sngFile.SetInt("hopo_frequency", customHOPO);
-                sngFile.SetBool("eighthnote_hopo", isEighthHOPO);
-                sngFile.SetInt("multiplier_note", multiplierNote);
-                sngFile.SetInt("delay", offset);
-                sngFile.SetInt("video_start_time", videoStart);
-                sngFile.SetBool("end_events", endEventsEnabled);
-                sngFile.SetString("loading_phrase", loadingPhrase);
-
-                foreach (var keyName in iniFile.GetKeyNames("song"))
-                {
-                    if (KnownKeys.IsKnownKey(keyName))
-                    {
-                        continue;
-                    }
-
-                    if (iniFile.TryGetBool("song", keyName, out var boolVal))
-                    {
-                        if (Program.Verbose)
-                        {
-                            ConMan.Out($"Unknown Key: {keyName} Value: {boolVal} BOOL");
-                        }
-                        sngFile.SetBool(keyName, boolVal);
-                    }
-                    else if (iniFile.TryGetInt("song", keyName, out var intVal))
-                    {
-                        if (Program.Verbose)
-                        {
-                            ConMan.Out($"Unknown Key: {keyName} Value: {intVal} INT");
-                        }
-                        sngFile.SetInt(keyName, intVal);
-                    }
-                    else if (iniFile.TryGetInt("song", keyName, out var floatVal))
-                    {
-                        if (Program.Verbose)
-                        {
-                            ConMan.Out($"Unknown Key: {keyName} Value: {floatVal} FLOAT");
-                        }
-                        sngFile.SetFloat(keyName, floatVal);
-                    }
-                    else if (iniFile.TryGetString("song", keyName, out var stringVal))
-                    {
-                        if (Program.Verbose)
-                        {
-                            ConMan.Out($"Unknown Key: {keyName} Value: {stringVal} STRING");
-                        }
-                        sngFile.SetString(keyName, stringVal);
-                    }
-                }
-                sngFile.metadataAvailable = true;
-
-                return true;
-            }
-            else
-            {
+            if (!iniFile.TryGetSection("song", out var section))
                 return false;
+
+            KnownKeys.ValidateKeys(section);
+
+            foreach (var (key, value) in section)
+            {
+                if (!KnownKeys.IsKnownKey(key) && Program.Verbose)
+                {
+                    ConMan.Out($"Unknown metadata. Key: {key} Value: {value}");
+                }
+                sngFile.SetString(key, value);
             }
+
+            sngFile.metadataAvailable = true;
+            return true;
         }
 
         private static readonly string videoPattern = @"(?i).*\.(mp4|avi|webm|vp8|ogv|mpeg)$";

--- a/SngTool/SngCli/SngEncodingOptions.cs
+++ b/SngTool/SngCli/SngEncodingOptions.cs
@@ -115,19 +115,25 @@ namespace SngCli
 
             if (args.TryGetValue("opusBitrate", out string? bitrateStr) && bitrateStr != null)
             {
-                if (!int.TryParse(bitrateStr, out OpusBitrate))
+                if (!int.TryParse(bitrateStr, out int opusBitrate))
                 {
                     Console.WriteLine($"Value for opusBitrate is not valid {bitrateStr}");
-                    return;
+                }
+                else
+                {
+                    OpusBitrate = opusBitrate;
                 }
             }
 
             if (args.TryGetValue("jpegQuality", out string? jpegQualityStr) && jpegQualityStr != null)
             {
-                if (!int.TryParse(jpegQualityStr, out JpegQuality))
+                if (!int.TryParse(jpegQualityStr, out int jpegQuality))
                 {
                     Console.WriteLine($"Value for jpegQuality is not valid {jpegQualityStr}");
-                    return;
+                }
+                else
+                {
+                    JpegQuality = jpegQuality;
                 }
             }
 
@@ -136,9 +142,11 @@ namespace SngCli
                 if (!ValidSize(albumSize))
                 {
                     Console.WriteLine($"Value for albumResize is not valid {albumSize}");
-                    return;
                 }
-                AlbumSize = SizeStrToEnum(albumSize);
+                else
+                {
+                    AlbumSize = SizeStrToEnum(albumSize);
+                }
             }
         }
     }

--- a/SngTool/SongLib/IniParser.cs
+++ b/SngTool/SongLib/IniParser.cs
@@ -108,6 +108,8 @@ namespace SongLib
                             continue;
                         writer.WriteLine($"{keyValue.Key} = {keyValue.Value}");
                     }
+
+                    writer.WriteLine();
                 }
             }
         }

--- a/SngTool/SongLib/IniParser.cs
+++ b/SngTool/SongLib/IniParser.cs
@@ -47,27 +47,8 @@ namespace SongLib
                         fileContent = fileContent.Slice(endOfLineIndex + 1);
                     }
 
-                    // Ignore any comments
-                    int commentIndex = line.IndexOfAny('#', ';');
-                    if (commentIndex >= 0)
-                    {
-                        var comment = line.Slice(commentIndex);
-
-                        // Check if this is a hex color code (e.g. #FFFFFF)
-                        if (comment[0] == '#' && comment.Length >= 7)
-                        {
-                            comment = comment[1..];
-                            int hexStopIndex = comment.IndexOfAnyExcept("0123456789ABCDEFabcdef");
-                            if (hexStopIndex is < 0 or >= 6)
-                            {
-                                commentIndex += hexStopIndex + 1;
-                            }
-                        }
-
-                        line = line.Slice(0, commentIndex).TrimEnd();
-                    }
-
-                    if (line.IsEmpty)
+                    // Ignore empty or comment lines
+                    if (line.IsEmpty || line[0] is '#' or ';')
                     {
                         continue;
                     }

--- a/SngTool/SongLib/IniParser.cs
+++ b/SngTool/SongLib/IniParser.cs
@@ -47,10 +47,24 @@ namespace SongLib
                         fileContent = fileContent.Slice(endOfLineIndex + 1);
                     }
 
+                    // Ignore any comments
                     int commentIndex = line.IndexOfAny('#', ';');
                     if (commentIndex >= 0)
                     {
-                        line = line.Slice(0, commentIndex);
+                        var comment = line.Slice(commentIndex);
+
+                        // Check if this is a hex color code (e.g. #FFFFFF)
+                        if (comment[0] == '#' && comment.Length >= 7)
+                        {
+                            comment = comment[1..];
+                            int hexStopIndex = comment.IndexOfAnyExcept("0123456789ABCDEFabcdef");
+                            if (hexStopIndex is < 0 or >= 6)
+                            {
+                                commentIndex += hexStopIndex + 1;
+                            }
+                        }
+
+                        line = line.Slice(0, commentIndex).TrimEnd();
                     }
 
                     if (line.IsEmpty)

--- a/SngTool/SongLib/IniParser.cs
+++ b/SngTool/SongLib/IniParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 
@@ -111,17 +112,14 @@ namespace SongLib
             }
         }
 
-        private IReadOnlyDictionary<string, string> emptyDict = new Dictionary<string, string>();
-
         // handle making section names case-insensitive as some charts use cased section names
-        public bool TryGetSection(string sectionName, out IReadOnlyDictionary<string, string> section)
+        public bool TryGetSection(string sectionName, [NotNullWhen(true)] out Dictionary<string, string>? section)
         {
-            section = emptyDict;
             if (!sections.TryGetValue(sectionName, out var value))
             {
-
                 if (!sections.TryGetValue(sectionName.ToLowerInvariant(), out value))
                 {
+                    section = null;
                     return false;
                 }
                 else

--- a/SngTool/SongLib/IniParser.cs
+++ b/SngTool/SongLib/IniParser.cs
@@ -106,7 +106,7 @@ namespace SongLib
                         // skip empty fields
                         if (string.IsNullOrEmpty(keyValue.Value))
                             continue;
-                        writer.WriteLine($"{keyValue.Key}={keyValue.Value}");
+                        writer.WriteLine($"{keyValue.Key} = {keyValue.Value}");
                     }
                 }
             }

--- a/SngTool/SongLib/IniParser.cs
+++ b/SngTool/SongLib/IniParser.cs
@@ -46,6 +46,12 @@ namespace SongLib
                         fileContent = fileContent.Slice(endOfLineIndex + 1);
                     }
 
+                    int commentIndex = line.IndexOfAny('#', ';');
+                    if (commentIndex >= 0)
+                    {
+                        line = line.Slice(0, commentIndex);
+                    }
+
                     if (line.IsEmpty)
                     {
                         continue;


### PR DESCRIPTION
Metadata handling and validation has been greatly refactored:

- Validation has been contained and made more data-oriented, to easily allow adding known metadata values without having to touch several spots of the code.
- Known metadata values which are missing from input files are no longer added in with default values, to prevent issues revolving around the tags which affect chart parsing. The person encoding the charts is now responsible for making sure all necessary metadata is present before conversion.
  - This fixes #2.
- Metadata values which are determined to be invalid are excluded from the output file. This is now the only form of metadata modification which will occur.
- Just about every song.ini tag I have in my chart docs has been added to the validation list, with special validation for specific tags added in as necessary.

There are various other changes I made along the way, just kept noticing things lol

- .ini parser now supports `#` and `;` comments, both on their own line and at the end of lines.
  - Hex color codes are also supported correctly, they will not be treated as comments.
- CLI args are now always parsed in full regardless of if invalid args exist. Invalid args are simply ignored and printed to the console.
- A .csproj warning about `SelfContained` no longer being the default when using a `RuntimeIdentifier` has been fixed by setting `SelfContained` to true.
- .opus encoding failed when debugging in VS Code due to an incorrect working directory, it needs to be set to the build output folder and not the project folder.
- `=` in written .ini files are now padded with a space on each side, for nicer reading.
- A newline is now written between each written .ini section.
- .sng decoding did not account for whenever no .sng files were detected, which would cause an exception in the progress bar drawing.