### PR TITLE
Edited SngLib source files to be source compatible when targeting Dotnet Standard2.1

### DIFF
--- a/SngTool/SngLib/LargeFile.cs
+++ b/SngTool/SngLib/LargeFile.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
 using System.Buffers;
 using Cysharp.Collections;
 

--- a/SngTool/SngLib/NativeByteArray/NativeByteArray.cs
+++ b/SngTool/SngLib/NativeByteArray/NativeByteArray.cs
@@ -1,5 +1,9 @@
 ﻿#nullable enable
 
+#if NET8_0_OR_GREATER
+#define WITH_INTEROPSERVICES_NATIVEMEMORY
+#endif
+
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -57,11 +61,22 @@ namespace Cysharp.Collections
             {
                 if (skipZeroClear)
                 {
+#if WITH_INTEROPSERVICES_NATIVEMEMORY
                     buffer = (byte*)NativeMemory.Alloc(checked((nuint)length), 1);
+#else
+                    int byteCount = (int)checked((uint)length) * 1;
+                    buffer = (byte*)Marshal.AllocHGlobal(byteCount);
+#endif
                 }
                 else
                 {
+#if WITH_INTEROPSERVICES_NATIVEMEMORY
                     buffer = (byte*)NativeMemory.AllocZeroed(checked((nuint)length), 1);
+#else
+                    int byteCount = (int)checked((uint)length) * 1;
+                    buffer = (byte*)Marshal.AllocHGlobal(byteCount);
+                    Unsafe.InitBlockUnaligned(buffer, 0, (uint)byteCount);
+#endif
                 }
 
                 if (addMemoryPressure)
@@ -109,7 +124,19 @@ namespace Cysharp.Collections
             // This vastly reduces the total number of re-allocations
             // with the drawback of increasing memory usage somewhat
             newLength = NextPO2(newLength);
+#if WITH_INTEROPSERVICES_NATIVEMEMORY
             buffer = (byte*)NativeMemory.Realloc(buffer, (nuint)newLength);
+#else
+            int byteCount = (int)newLength;
+            byte* newBuffer = (byte*)Marshal.AllocHGlobal(byteCount);
+
+            Span<byte> src = new Span<byte>(buffer, (int)length);
+            Span<byte> dst = new Span<byte>(newBuffer, (int)byteCount);
+            src.CopyTo(dst);
+
+            Marshal.FreeHGlobal((IntPtr)buffer);
+            buffer = newBuffer;
+#endif
 
             allocatedLength = newLength;
             length = newLength;
@@ -291,7 +318,11 @@ namespace Cysharp.Collections
                 isDisposed = true;
                 if (Unsafe.IsNullRef(ref Unsafe.AsRef<byte>(buffer))) return;
 
+#if WITH_INTEROPSERVICES_NATIVEMEMORY
                 NativeMemory.Free(buffer);
+#else
+                Marshal.FreeHGlobal((IntPtr)buffer);
+#endif
                 if (addMemoryPressure)
                 {
                     GC.RemoveMemoryPressure(length * Unsafe.SizeOf<byte>());

--- a/SngTool/SngLib/NativeByteArray/NativeByteArray.cs
+++ b/SngTool/SngLib/NativeByteArray/NativeByteArray.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 
-#if NET8_0_OR_GREATER
+#if NET6_0_OR_GREATER
 #define WITH_INTEROPSERVICES_NATIVEMEMORY
 #endif
 

--- a/SngTool/SngLib/NativeByteArray/NativeByteArrayExtensions.cs
+++ b/SngTool/SngLib/NativeByteArray/NativeByteArrayExtensions.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 
-#if !NETSTANDARD2_0 && !UNITY_2019_1_OR_NEWER
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
 
 using System;
 using System.IO;

--- a/SngTool/SngLib/SngFile.cs
+++ b/SngTool/SngLib/SngFile.cs
@@ -12,8 +12,8 @@ namespace SngLib
 
         public bool metadataAvailable;
 
-        public Dictionary<string, string> Metadata = new();
-        public Dictionary<string, NativeByteArray?> Files = new();
+        public Dictionary<string, string> Metadata = new Dictionary<string, string>();
+        public Dictionary<string, NativeByteArray?> Files = new Dictionary<string, NativeByteArray?>();
 
         public void AddFile(string fileName, NativeByteArray? data)
         {

--- a/SngTool/SngLib/SngFile.cs
+++ b/SngTool/SngLib/SngFile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Cysharp.Collections;
 

--- a/SngTool/SngLib/SngSerializer.cs
+++ b/SngTool/SngLib/SngSerializer.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Linq;
 using System.Numerics;
 using System.Text;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using BinaryEx;
 using Cysharp.Collections;
 

--- a/SngTool/SngLib/SngSerializer.cs
+++ b/SngTool/SngLib/SngSerializer.cs
@@ -79,7 +79,16 @@ namespace SngLib
                 Vector<byte> dataVector = new Vector<byte>(data.Slice(byteIndex));
 
                 Vector<byte> maskedData = dataVector ^ dataIndexVectors![lookupIndex & lookupSizeMask];
+#if NET5_0_OR_GREATER
                 maskedData.CopyTo(data.Slice(byteIndex));
+#else
+                var destination = data.Slice(byteIndex);
+                if (destination.Length < Vector<byte>.Count)
+                {
+                    throw new ArgumentException("Destination is too short");
+                }
+                Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(data.Slice(byteIndex)), maskedData);
+#endif
             }
 
             long endOfVecFilePos = filePos + totalVecElements;


### PR DESCRIPTION
This allows sng lib source files to be used directly within later versions of Unity, as well as building dlls that target the dot net standard. 